### PR TITLE
fix: 셋리스트 조회에 현재 곡 정보 제거

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -209,15 +209,10 @@ public class PerformanceServiceImpl implements PerformanceService {
                         p.getSong().getTitle(),
                         p.getSong().getArtist()
                 ))
-                .sorted(Comparator.comparingInt(PerformanceSetListDetail::order)) // order 기준 정렬
+                .sorted(Comparator.comparingInt(PerformanceSetListDetail::order))
                 .toList();
 
-        // currentSong이 null일 수 있는 경우 처리
-        int currentSongId = performance.getCurrentSong() != null
-                ? performance.getCurrentSong().getOrderInPerformance()
-                : -1;
-
-        return new PerformanceSetlistResponse(currentSongId, performance.getSetlistUrl(), setList);
+        return new PerformanceSetlistResponse(setList);
     }
 
     // BandSession 생성 헬퍼 메서드

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceSetlistResponse.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceSetlistResponse.java
@@ -1,16 +1,14 @@
 package com.deulbull.performance.domain.performance.web.dto;
+
 import java.util.List;
 
 public record PerformanceSetlistResponse(
-        int nowPlayingOrder,
-        String setListUrl,
         List<PerformanceSetListDetail> setlist
 ) {
     public record PerformanceSetListDetail(
-        int order,
-        Long performanceSongId,
-        String title,
-        String artist
-    ){
-    }
+            int order,
+            Long performanceSongId,
+            String title,
+            String artist
+    ) {}
 }


### PR DESCRIPTION
## 연관 이슈
- close #3 

## 작업 내용
- 셋리스트 조회 api에 현재 곡 관련 정보 제거
