### PR TITLE
fix: 공연 정보 상세 조회에 사전예매 url 및 전화번호 필드 추가

### DIFF
--- a/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/entity/Performance.java
@@ -31,6 +31,8 @@ public class Performance extends BaseEntity {
     private String posterFrontUrl; // 포스터 앞면 이미지 URL
     private String posterBackUrl;  // 포스터 뒷면 이미지 URL
     private String openchatUrl;
+    private String phoneNumber; // 연락처 (010-xxxx-xxxx), null 가능
+    private String preSaleFormUrl; // 사전예매 폼 URL, null 가능
     private String bankName; // 은행명
     private String bankAccount; // 계좌번호
     private String accountHolder; // 예금주

--- a/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/service/PerformanceServiceImpl.java
@@ -68,6 +68,8 @@ public class PerformanceServiceImpl implements PerformanceService {
                 .posterFrontUrl(null)
                 .posterBackUrl(null)
                 .openchatUrl(basicInfo.phoneNumber())
+                .phoneNumber(basicInfo.phoneNumber())
+                .preSaleFormUrl(basicInfo.preSaleFormUrl())
                 .bankName(basicInfo.bankName())
                 .bankAccount(basicInfo.bankAccount())
                 .accountHolder(basicInfo.accountHolder())
@@ -187,7 +189,8 @@ public class PerformanceServiceImpl implements PerformanceService {
                 performance.getTitle(),
                 dateTimeFormatted,
                 performance.getVenue(),
-                performance.getOpenchatUrl(),
+                performance.getPreSaleFormUrl(),
+                performance.getPhoneNumber(),
                 posterUrls,
                 performance.getLocation()
         );

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateBasicDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceCreateBasicDto.java
@@ -24,6 +24,7 @@ public record PerformanceCreateBasicDto(
         LocalDateTime dateTime,
 
         String phoneNumber,
+        String preSaleFormUrl,
 
         Integer preSaleFee,
         Integer onSiteFee,

--- a/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceDetailResponseDto.java
+++ b/src/main/java/com/deulbull/performance/domain/performance/web/dto/PerformanceDetailResponseDto.java
@@ -8,6 +8,7 @@ public record PerformanceDetailResponseDto(
         String title,
         String dateTime,
         String venue,
+        String preSaleFormUrl,
         String phoneNumber,
         List<String> posterUrls,
         String location


### PR DESCRIPTION
## 연관 이슈
- close #5 

## 작업 내용
- 공연 상세 정보 조회 시 사전예매 url 및 전화번호 반환되도록 수정
- 공연 생성 api에도 반영